### PR TITLE
Migrate zippers benchmark from lens

### DIFF
--- a/benchmarks/zipper.hs
+++ b/benchmarks/zipper.hs
@@ -1,0 +1,46 @@
+module Main
+       ( main -- :: IO ()
+       ) where
+
+import Control.Lens
+import Control.Zipper
+import Criterion.Main
+
+main :: IO ()
+main = defaultMain
+  [ bgroup "rezip"
+      [ bench "rezip"             $ nf tugAndRezip1 ['a'..'z']
+      , bench "farthest leftward" $ nf tugAndRezip2 ['a'..'z']
+      , bench "leftmost"          $ nf tugAndRezip3 ['a'..'z']
+      , bench "tugTo"             $ nf tugAndRezip4 ['a'..'z']
+      ]
+  , bgroup "zipper creation"
+      [ bench "over traverse id"  $ nf (over traverse id) ['a'..'z']
+      , bench "zipper"            $ nf zipTraverseRezip   ['a'..'z']
+      ]
+  , bgroup "downward"
+      [ bench "downward _1"       $ nf downwardAndRezip1 (['a'..'z'],['z'..'a'])
+      , bench "fromWithin"        $ nf downwardAndRezip2 (['a'..'z'],['z'..'a'])
+      ]
+  ]
+
+-- What's the fastest rezip of all?
+tugAndRezip1, tugAndRezip2, tugAndRezip3 :: String -> String
+tugAndRezip1 xs = zipntugs 25 xs & focus .~ 'a' & rezip
+tugAndRezip2 xs = zipntugs 25 xs & focus .~ 'b' & farthest leftward & rezip
+tugAndRezip3 xs = zipntugs 25 xs & focus .~ 'c' & leftmost & rezip
+tugAndRezip4 xs = zipntugs 25 xs & focus .~ 'd' & tugTo 0 & rezip
+
+zipntugs i x = zipper x & fromWithin traverse & tugs rightward i
+
+-- How fast is creating and destroying a zipper compared to
+-- a regular traversal?
+zipTraverseRezip x = zipper x & fromWithin traverse & rezip
+
+-- is 'downward' any faster than the composition of traverse?
+downwardAndRezip1 :: (String, String) -> (String, String)
+downwardAndRezip1 xs =
+  zipper xs & downward _1 & fromWithin traverse & focus .~ 'h' & rezip
+downwardAndRezip2 :: (String, String) -> (String, String)
+downwardAndRezip2 xs =
+  zipper xs & fromWithin (_1.traverse) & focus .~ 'g' & rezip

--- a/zippers.cabal
+++ b/zippers.cabal
@@ -55,3 +55,15 @@ test-suite doctests
   if impl(ghc<7.6.1)
     ghc-options: -Werror
   hs-source-dirs: tests
+
+benchmark zipper
+  type:             exitcode-stdio-1.0
+  main-is:          zipper.hs
+  default-language: Haskell2010
+  ghc-options:      -w -O2 -threaded -fdicts-cheap -funbox-strict-fields
+  hs-source-dirs:   benchmarks
+  build-depends:
+    base,
+    criterion,
+    lens,
+    zippers


### PR DESCRIPTION
While fixing `lens`' benchmarks for https://github.com/fpco/stackage/issues/1372#issuecomment-213020065, I noticed that `lens` still had [a benchmark for zippers](https://github.com/ekmett/lens/blob/dd6cc120ac128a732614c3f0aab7e72bb716e630/benchmarks/zipper.hs), even though that had since been moved to this package. This completes the transition.