### PR TITLE
Fix Issue #10

### DIFF
--- a/src/Control/Zipper/Internal.hs
+++ b/src/Control/Zipper/Internal.hs
@@ -282,7 +282,7 @@ movel :: Path i a -> Jacket i a -> r -> (Path i a -> i -> a -> r) -> r
 movel p0 c0 kn kp = go p0 c0 where
   go Start _ = kn
   go (ApR m _ _ li l q) r
-    | nullRight l = go q (Ap m False False li l Pure)
+    | nullRight l = go q (Ap m False False li Pure r)
     | otherwise   = startr (ApL m False False li q r) l kn kp
   go (ApL m _ _ li p r) l = go p (Ap m False False li l r)
 {-# INLINE movel #-}
@@ -292,7 +292,7 @@ mover :: Path i a -> Jacket i a -> r -> (Path i a -> i -> a -> r) -> r
 mover p0 c0 kn kp = go p0 c0 where
   go Start _ = kn
   go (ApL m _ _ li q r) l
-    | nullLeft r  = go q (Ap m False False li Pure r)
+    | nullLeft r  = go q (Ap m False False li l Pure)
     | otherwise   = startl (ApR m False False li l q) r kn kp
   go (ApR m _ _ li l p) r = go p (Ap m False False li l r)
 {-# INLINE mover #-}


### PR DESCRIPTION
The old code said "If the left branch is empty, then ignore the right branch", which is obviously wrong.
The intended behavior was to replace the empty branch with a "Pure".

### Test case:


```
import Control.Zipper
import Control.Lens

-- A tree with potentially empty branches
data T a = Lf a | Nil | Node (T a) (T a) deriving Show

-- A traversal for the tree
trav :: Traversal (T a) (T b) a b
trav k = go where
 go Nil        = pure Nil
 go (Lf a)     = Lf <$> k a
 go (Node a b) = Node <$> go a <*> go b

-- This tree triggers the bug.
brokenTree :: T Int
brokenTree = (Lf 1`Node`Nil) `Node` Lf 2

main =   zipper brokenTree
     &   within trav -- A zipper pointing at "Lf 1"
     >>= rightward   -- At this point, the "Lf 1" is forgotten
     <&> rezip       -- This line fails with "jacketOuts: wrong shape"
     >>= print

```

This is (most likely) the cause of bug #10.