### PR TITLE
ipull/pull: move in any direction and pass the result to a continuation

### DIFF
--- a/src/Control/Zipper.hs
+++ b/src/Control/Zipper.hs
@@ -62,6 +62,11 @@ module Control.Zipper
   -- ** Lateral Movement
   , leftward, rightward
   , leftmost, rightmost
+  -- ** General Movement
+  , ZipperDirection(..)
+  , UniformZipper()
+  , pull
+  , ipull
   -- ** Movement Combinators
   , tug
   , tugs

--- a/src/Control/Zipper/Internal.hs
+++ b/src/Control/Zipper/Internal.hs
@@ -487,8 +487,8 @@ data ZipperDirection = ZLeft | ZRight | ZUp | ZDown
   deriving (Show, Read, Eq, Ord)
 
 -- | A 'Zipper' where all the indexes and values are of type @i@ and @a@.
-class UniformZipper i a h where
-  maybeUpward :: MonadPlus m => h :> a:@i -> (forall h'. h' :> a:@i -> m r) -> m r
+class (Zipped h a ~ a, Zipping h a) => UniformZipper i a h where
+  maybeUpward :: MonadPlus m => h :> a:@i -> (forall h'. UniformZipper i a h' => h' :> a:@i -> m r) -> m r
 
 instance UniformZipper i a Top where
   maybeUpward _ _ = mzero
@@ -512,7 +512,7 @@ pull
   => LensLike' (Indexing (Bazaar' (Indexed Int) a)) a a
   -> ZipperDirection
   -> h :>> a
-  -> (forall h'. h' :>> a -> m r)
+  -> (forall h'. UniformZipper Int a h' => h' :>> a -> m r)
   -> m r
 pull trav = ipull (indexing trav)
 
@@ -532,7 +532,7 @@ ipull
   => AnIndexedTraversal' i a a
   -> ZipperDirection
   -> h :> a:@i
-  -> (forall h'. h' :> a:@i -> m r)
+  -> (forall h'. UniformZipper i a h' => h' :> a:@i -> m r)
   -> m r
 ipull itrav op z k = case op of
   ZLeft -> leftward z >>= k

--- a/src/Control/Zipper/Internal.hs
+++ b/src/Control/Zipper/Internal.hs
@@ -346,7 +346,8 @@ data Top
 -- unpacked and stored in 'Coil' form. Only one value of type @_ ':>' _@ exists
 -- at any particular time for any particular 'Zipper'.
 
-data Zipper h i a = Ord i => Zipper !(Coil h i a) Int !Int !(Path i a) i a
+data Zipper h i a where
+  Zipper :: Ord i => !(Coil h i a) -> Int -> !Int -> !(Path i a) -> i -> a -> Zipper h i a
 
 -- Top :>> Map String Int :> Int :@ String :>> Bool
 
@@ -383,7 +384,7 @@ type instance Zipped (Zipper h i a) s = Zipped h a
 #ifndef HLINT
 data Coil t i a where
   Coil :: Coil Top Int a
-  Snoc :: Ord i => !(Coil h j s) -> AnIndexedTraversal' i s a -> Int -> !Int -> !(Path j s) -> j -> (Jacket i a -> s) -> Coil (Zipper h j s) i a
+  Snoc :: (Ord i, Ord j) => !(Coil h j s) -> AnIndexedTraversal' i s a -> Int -> !Int -> !(Path j s) -> j -> (Jacket i a -> s) -> Coil (Zipper h j s) i a
 #endif
 
 -- | This 'Lens' views the current target of the 'Zipper'.


### PR DESCRIPTION
As mentioned in the docstring:

> This is useful when you need to act on a zipper based on user input, and therefore can't specify what the result zipper type would be. Instead, it is passed to a continuation that can take any (uniform) zipper type. Typically, the continuation could call this same function again, e.g. in a REPL.

Implementing this feature requires dropping the `Ord i =>` data context on Zipper, which is a deprecated GHC extension anyways, so if you don't like this overall feature hopefully we can still merge this fix - it is required, even for me to keep this feature in my own package.
